### PR TITLE
Remove dependency on merge to fix npm audit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "app-root-path": "^2.2.1",
     "cheerio": "^1.0.0-rc.2",
     "clean-css": "^4.2.1",
-    "glob": "^7.1.3",
-    "merge": "^1.2.1"
+    "glob": "^7.1.3"
   },
   "directories": {
     "test": "test"

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ const cheerio = require('cheerio');
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
-const merge = require('merge');
 const cleanCSS = require('clean-css');
 var appRoot = require('app-root-path');
 
@@ -28,7 +27,7 @@ module.exports = function (options) {
 
     let appRootPath = appRoot.path;
 
-    let opts = merge(defaultOpts, options);
+    let opts = Object.assign(defaultOpts, options);
     let root = path.resolve(appRootPath, opts.coverageDir);
     let globPattern = root + opts.pattern;
     // console.log(globPattern);


### PR DESCRIPTION
The version of the merge package used had a vulnerability and since it can be easily substituted with `Object.assign()` in this case I've removed it instead of updating.